### PR TITLE
added coord filter

### DIFF
--- a/traffic_api/views.py
+++ b/traffic_api/views.py
@@ -37,10 +37,24 @@ def receive_data(request):
 
 @csrf_exempt
 def all_intersection_activity(request):
-    out_data = IntersectionData.objects.all()
+
+    lat_lte = request.GET.get('lat_lte', '')
+    lat_gte = request.GET.get('lat_gte', '')
+    lon_gte = request.GET.get('lon_gte', '')
+    lon_lte = request.GET.get('lon_lte', '')
+
+    # Check if we have coordinates.
+    if lat_lte and lat_gte and lon_gte and lon_lte:
+        filtered = IntersectionData.objects.filter(
+            latitude__gte=lat_gte,
+            latitude__lte=lat_lte,
+            longitude__gte=lon_gte,
+            longitude__lte=lon_lte)
+    else:
+        filtered = IntersectionData.objects.all()
 
     # Convert all objects to dict.
-    results = [ob.as_json() for ob in out_data]
+    results = [ob.as_json() for ob in filtered]
 
     # Append car observations.
     hour = int(time.strftime("%H"))


### PR DESCRIPTION
# What Changed

+ Added a coordinate filter.

We can handle queries like this now:

`/traffic/intersections?lat_gte=49.2270544&lat_lte=49.2748495&lon_lte=-123.0967973&lon_gte=-123.2430845`

#### New parameters 
+ `lat_gte`: latitude greater than or equal to.
+ `lat_lte`: latitude less than or equal to.
+ `lon_lte`: latitude less than or equal to.
+ `lon_gte`: latitude greater than or equal to.

This should speed things up on the app side so you don't have to load in the whole city worth of coords.

## How to Test Drive

```
git checkout add_coord_filter
python manage.py runserver

# In another terminal
curl http://127.0.0.1:8000/traffic/intersections?lat_gte=49.2270544&lat_lte=49.2748495&lon_lte=-123.0967973&lon_gte=-123.2430845
```