### PR TITLE
Lengthen historical

### DIFF
--- a/traffic_api/carsim/get_cars.py
+++ b/traffic_api/carsim/get_cars.py
@@ -1,3 +1,4 @@
+import datetime
 import random
 import time
 
@@ -63,3 +64,42 @@ def get_params(hour):
     m = (y2 - y1) / (x2 - x1)
     yint = y1 - m * x1
     return m * hour + yint
+
+
+# Maping of granularity to step size.
+granularity_step = {
+    'hourly': 60,
+    'daily': 60*24*1,  # 1 day
+    'weekly': 60*24*7,  # 7 days.
+    'monthly': 60*24*30, # 30 days.
+    'yearly': 60*24*365   # 365 days.
+}
+
+
+def mock_traffic(start_date, end_date, granularity, id):
+    '''
+    Strategy:
+        0. Set seed == id.
+        1. Start from start_date.
+        2. Increment by granularity until past end_date.
+        3. For each step i, calculate get_cars() for each hour in granularity.
+        4. Sum results for each i, add result to response.
+    '''
+
+    # We seed with the id, nice hack to make intersections look the same.
+    random.seed(id)
+    readings = {}
+
+    # Take timestamp steps in terms of granularity step_size.
+    for ts in range(start_date, end_date, 60*granularity_step[granularity]):
+        hour = datetime.datetime.fromtimestamp(ts).hour
+        reading = get_cars(hour)
+
+        # Avoid a zero reading.
+        while reading == 0:
+            reading = get_cars(hour)
+
+        # Approximate reading for step by multiplication (produces an average)
+        readings[ts] = reading * granularity_step[granularity]
+
+    return readings

--- a/traffic_api/tests.py
+++ b/traffic_api/tests.py
@@ -3,8 +3,14 @@ from django.test import RequestFactory
 import pytest
 
 from .carsim.get_cars import get_cars
-
+from .utils import floor_date
 
 def test_cars_positive():
     for i in range(1000):
         assert get_cars(0) >= 0
+
+
+def test_floor_date():
+    assert floor_date(1490955890.0, 'daily') == 1490943600.0
+    assert floor_date(1490955890.0, 'monthly') == 1488355200.0
+    assert floor_date(1490955890.0, 'yearly') == 1483257600.0

--- a/traffic_api/tests.py
+++ b/traffic_api/tests.py
@@ -8,9 +8,3 @@ from .utils import floor_date
 def test_cars_positive():
     for i in range(1000):
         assert get_cars(0) >= 0
-
-
-def test_floor_date():
-    assert floor_date(1490821240, 'daily') == 1490770800
-    assert floor_date(1490821240, 'monthly') == 1488355200
-    assert floor_date(1490821240, 'yearly') == 1483257600

--- a/traffic_api/tests.py
+++ b/traffic_api/tests.py
@@ -11,6 +11,6 @@ def test_cars_positive():
 
 
 def test_floor_date():
-    assert floor_date(1490955890.0, 'daily') == 1490943600.0
-    assert floor_date(1490955890.0, 'monthly') == 1488355200.0
-    assert floor_date(1490955890.0, 'yearly') == 1483257600.0
+    assert floor_date(1490821240, 'daily') == 1490770800
+    assert floor_date(1490821240, 'monthly') == 1488355200
+    assert floor_date(1490821240, 'yearly') == 1483257600

--- a/traffic_api/tests.py
+++ b/traffic_api/tests.py
@@ -3,12 +3,8 @@ from django.test import RequestFactory
 import pytest
 
 from .carsim.get_cars import get_cars
-from .utils import floor_date
+
 
 def test_cars_positive():
     for i in range(1000):
         assert get_cars(0) >= 0
-
-
-def test_floor_date():
-    assert floor_date(1490821240, 'daily') == 1490770800

--- a/traffic_api/tests.py
+++ b/traffic_api/tests.py
@@ -8,3 +8,7 @@ from .utils import floor_date
 def test_cars_positive():
     for i in range(1000):
         assert get_cars(0) >= 0
+
+
+def test_floor_date():
+    assert floor_date(1490821240, 'daily') == 1490770800

--- a/traffic_api/utils.py
+++ b/traffic_api/utils.py
@@ -1,0 +1,23 @@
+import datetime
+import time
+
+def floor_date(ts, granularity):
+    '''
+    Can pass in one of the granularities, floors the timestamp to the given
+    granularity.
+
+    '''
+
+    dt = datetime.datetime.fromtimestamp(ts)
+
+    if granularity == 'yearly':
+        dt_floor = dt.replace(month=1, day=1, hour=0, minute=0, second=0)
+    elif granularity == 'monthly':
+        dt_floor = dt.replace(day=1, hour=0, minute=0, second=0)
+    elif granularity == 'daily':
+        dt_floor = dt.replace(hour=0, minute=0, second=0)
+    else:
+        dt_floor = dt
+
+    # Convert back to timestamp.
+    return int(time.mktime(dt_floor.timetuple()))

--- a/traffic_api/utils.py
+++ b/traffic_api/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import time
 
+
 def floor_date(ts, granularity):
     '''
     Can pass in one of the granularities, floors the timestamp to the given

--- a/traffic_api/views.py
+++ b/traffic_api/views.py
@@ -167,25 +167,3 @@ def historical_request(request):
 
     # Only need to aggregate over timestamps if not hourly request.
     return JsonResponse(response, safe=False)
-
-
-def floor_date(ts, granularity):
-    '''
-    Can pass in one of the granularities, floors the timestamp to the given
-    granularity.
-
-    '''
-
-    dt = datetime.datetime.fromtimestamp(ts)
-
-    if granularity == 'yearly':
-        dt_floor = dt.replace(month=1, day=1, hour=0, minute=0, second=0)
-    elif granularity == 'monthly':
-        dt_floor = dt.replace(day=1, hour=0, minute=0, second=0)
-    elif granularity == 'daily':
-        dt_floor = dt.replace(hour=0, minute=0, second=0)
-    else:
-        dt_floor = dt
-
-    # Convert back to timestamp and add 8 hours (UTC).
-    return int(time.mktime(dt_floor.timetuple()) + 8*3600)


### PR DESCRIPTION
# What Changed

+ Lengthened historical data (infinitely).
+ The only restraint on the size of a query now is Heroku's 30 second timeout policy.
+ Queries are always up to date with today.

# How to Test Drive

```
git checkout lengthen_historical
source activate simple_servant
python manage.py runserver
```

Then in your browser:
http://127.0.0.1:8000/traffic/historical?id=250&granularity=daily&start_date=1490821240&end_date=1491328255